### PR TITLE
Whisper Demo: Setting VAD minBufferSize by LCM of chunkLength and AudioWorklet process length

### DIFF
--- a/js/whisper-demo/index.js
+++ b/js/whisper-demo/index.js
@@ -40,6 +40,9 @@ function updateConfig() {
         if (pair[0] == 'maxChunkLength') {
             options.maxChunkLength = parseFloat(pair[1]);
         }
+        if (pair[0] == 'chunkLength') {
+            options.chunkLength = parseFloat(pair[1]);
+        }
         if (pair[0] == 'verbose') {
             options.verbose = pair[1].toLowerCase() === 'true';
         }
@@ -68,13 +71,13 @@ function ready() {
 
 const recognitionClient = {
     _onstart: () => {
-        console.log('recognitionClient._onstart');
+        log('Recognition starts');
     },
     _onend: () => {
-        console.log('recognitionClient._onend');
+        log('Recognition ends');
     },
     _onresult: (transcript, isFinal) => {
-        console.log(`recognitionClient._onresult: transcript: ${transcript}, isFinal: ${isFinal}`);
+        console.log(`Recognition ${isFinal ? 'final' : 'interim'} result:${transcript}`);
         if (!isFinal) {
             textarea.value = speechToText + transcript;
         } else {
@@ -84,7 +87,7 @@ const recognitionClient = {
         textarea.scrollTop = textarea.scrollHeight;
     },
     _onerror: (e) => {
-        log(`Speech error: ${e}`);
+        log(`Recognition error: ${e}`);
     }
 };
 

--- a/js/whisper-demo/index.js
+++ b/js/whisper-demo/index.js
@@ -43,6 +43,9 @@ function updateConfig() {
         if (pair[0] == 'chunkLength') {
             options.chunkLength = parseFloat(pair[1]);
         }
+        if (pair[0] == 'maxAudioLength') {
+            options.maxAudioLength = parseFloat(pair[1]);
+        }
         if (pair[0] == 'verbose') {
             options.verbose = pair[1].toLowerCase() === 'true';
         }
@@ -77,10 +80,11 @@ const recognitionClient = {
         log('Recognition ends');
     },
     _onresult: (transcript, isFinal) => {
-        console.log(`Recognition ${isFinal ? 'final' : 'interim'} result:${transcript}`);
+        console.log(`${isFinal ? 'final' : 'interim'} result:${transcript}`);
         if (!isFinal) {
             textarea.value = speechToText + transcript;
         } else {
+            transcript += '\r\n';
             speechToText += transcript;
             textarea.value = speechToText;
         }
@@ -172,7 +176,7 @@ async function transcribe_file() {
         source.start();
         const renderedBuffer = await offlineContext.startRendering();
         const audio = renderedBuffer.getChannelData(0);
-        await process_audio(audio, performance.now(), 0, 0, textarea);
+        await process_audio(audio, performance.now(), 0, 0, textarea, progress);
         ready();
     }
     catch (e) {

--- a/js/whisper-demo/main.js
+++ b/js/whisper-demo/main.js
@@ -11,7 +11,6 @@ import { lcm } from "./vad/math.js";
 
 const kSampleRate = 16000;
 const kSteps = kSampleRate * 30;
-const kDelay = 100;
 
 // whisper class
 let whisper;
@@ -135,10 +134,6 @@ export async function initWhisper(ort, AutoProcessor, AutoTokenizer, options) {
     return true;
 }
 
-function sleep(ms) {
-    return new Promise(resolve => setTimeout(resolve, ms));
-}
-
 // process audio buffer
 export async function process_audio(audio, starttime, idx, pos, textarea, progress) {
     if (idx < audio.length) {
@@ -147,14 +142,12 @@ export async function process_audio(audio, starttime, idx, pos, textarea, progre
             // update progress bar
             progress.style.width = (idx * 100 / audio.length).toFixed(1) + "%";
             progress.textContent = progress.style.width;
-            await sleep(kDelay);
             // run inference for 30 sec
             const xa = audio.slice(idx, idx + kSteps);
             const ret = await whisper.run(xa);
             // append results to textarea 
             textarea.value += ret;
             textarea.scrollTop = textarea.scrollHeight;
-            await sleep(kDelay);
             await process_audio(audio, starttime, idx + kSteps, pos + 30, textarea, progress);
         } catch (e) {
             log(`Error: ${e}`);

--- a/js/whisper-demo/main.js
+++ b/js/whisper-demo/main.js
@@ -10,7 +10,8 @@ import VADBuilder, { VADMode, VADEvent } from "./vad/embedded.js";
 import { lcm } from "./vad/math.js";
 
 const kSampleRate = 16000;
-const kSteps = kSampleRate * 30;
+const kMaxAudioLengthInSec = 30;
+const kSteps = kSampleRate * kMaxAudioLengthInSec;
 
 // whisper class
 let whisper;
@@ -46,7 +47,7 @@ let subAudioChunks = [];
 let accumulateSubChunks = false; // Accumulate the sub audio chunks for one processing.
 let chunkLength = 1 / 25; // length in sec of one audio chunk from AudioWorklet processor, recommended by vad
 let maxChunkLength = 1; // max audio length in sec for a single audio processing
-let maxAudioLength = 10; // max audio length in sec for rectification
+let maxAudioLength = 10; // max audio length in sec for rectification, must not be greater than 30 sec
 let maxUnprocessedAudioLength = 0;
 let maxProcessAudioBufferLength = 0;
 let verbose = false;
@@ -100,7 +101,7 @@ function updateConfig(options) {
             chunkLength = options.chunkLength;
         }
         if (options.maxAudioLength !== undefined) {
-            maxAudioLength = options.maxAudioLength;
+            maxAudioLength = Math.min(options.maxAudioLength, kMaxAudioLengthInSec);
         }
         if (options.verbose !== undefined) {
             verbose = options.verbose;
@@ -148,7 +149,7 @@ export async function process_audio(audio, starttime, idx, pos, textarea, progre
             // append results to textarea 
             textarea.value += ret;
             textarea.scrollTop = textarea.scrollHeight;
-            await process_audio(audio, starttime, idx + kSteps, pos + 30, textarea, progress);
+            await process_audio(audio, starttime, idx + kSteps, pos + kMaxAudioLengthInSec, textarea, progress);
         } catch (e) {
             log(`Error: ${e}`);
         }

--- a/js/whisper-demo/streaming_processor.js
+++ b/js/whisper-demo/streaming_processor.js
@@ -1,19 +1,21 @@
+const audioDataSize = 128;
+
 class StreamingProcessor extends AudioWorkletProcessor {
     constructor(options) {
         super();
 
-        this.publishInterval = 0;
-        this.index = 0; // index of this._streamingBuffer data
+        this.minBufferSize = 0;
+        this.length = 0; // length of this._streamingBuffer data
         if (options && options.processorOptions) {
             const {
                 minBufferSize,
             } = options.processorOptions;
 
-            // We will use a timer to gate our messages; this one will publish at 60hz
-            this.publishInterval = minBufferSize;
+            this.minBufferSize = minBufferSize;
+            console.assert(minBufferSize % audioDataSize === 0, `${minBufferSize} % ${audioDataSize} is not 0`);
         }
         this.stopProcessing = false;
-        this._streamingBuffer = new Float32Array(this.publishInterval);
+        this._streamingBuffer = new Float32Array(this.minBufferSize);
 
         this.port.onmessage = e => {
             if (e.data.message === 'STOP_PROCESSING') {
@@ -27,21 +29,17 @@ class StreamingProcessor extends AudioWorkletProcessor {
             // Do nothing, suspend the audio processing
         } else {
             // inputs[0][0]'s length is 128
-            for (let sample = 0; sample < inputs[0][0].length; sample++) {
-                const currentSample = inputs[0][0][sample];
-
-                // Copy data to streaming buffer.
-                this._streamingBuffer[this.index] = currentSample;
-                this.index++;
-                // Should publish, clear this._streamingBuffer and this.index
-                if (this.index == this.publishInterval) {
-                    this.port.postMessage({
-                        message: 'START_TRANSCRIBE',
-                        buffer: this._streamingBuffer,
-                    }, [this._streamingBuffer.buffer.slice()]);
-                    this._streamingBuffer.fill(0);
-                    this.index = 0;
-                }
+            console.assert(inputs[0][0].length === audioDataSize, `${inputs[0][0].length} is not ${audioDataSize}`);
+            this._streamingBuffer.set(inputs[0][0], this.length);
+            this.length += inputs[0][0].length;
+            // Should publish, clear this._streamingBuffer and this.index
+            if (this.length == this.minBufferSize) {
+                this.port.postMessage({
+                    message: 'START_TRANSCRIBE',
+                    buffer: this._streamingBuffer,
+                }, [this._streamingBuffer.buffer.slice()]);
+                this._streamingBuffer.fill(0);
+                this.length = 0;
             }
         }
         return true;

--- a/js/whisper-demo/streaming_processor.js
+++ b/js/whisper-demo/streaming_processor.js
@@ -2,18 +2,15 @@ class StreamingProcessor extends AudioWorkletProcessor {
     constructor(options) {
         super();
 
-        this.sampleRate = 0;
         this.publishInterval = 0;
         this.index = 0; // index of this._streamingBuffer data
         if (options && options.processorOptions) {
             const {
-                sampleRate,
-                chunkLength,
+                minBufferSize,
             } = options.processorOptions;
 
-            this.sampleRate = sampleRate;
             // We will use a timer to gate our messages; this one will publish at 60hz
-            this.publishInterval = chunkLength * sampleRate;
+            this.publishInterval = minBufferSize;
         }
         this.stopProcessing = false;
         this._streamingBuffer = new Float32Array(this.publishInterval);


### PR DESCRIPTION
The changes include:
1. Allows setting `chunkLength` and `maxAudioLength` by users.
1. Sets the VAD `minBufferSize` by LCM (longest common multiply) of user set `chunkLength`, AudioWorklet processing data length (128) and VAD internal buffer size (by calling `vad.getMinBufferSize()`).
1. Because minBufferSize is now a multiply of AudioWorklet processing data length (128), appends the audio data to streaming buffer in oneshot (by `Float32Array.set()`). That would improve the performance a bit.
1. Fixes progress bar display issue.
1. Adds more info log, like max processed buffer size and max unprocessed audio length.

@Honry , PTAL, thanks!